### PR TITLE
remove useless list comprehension.

### DIFF
--- a/fleep/__init__.py
+++ b/fleep/__init__.py
@@ -77,7 +77,7 @@ def get(obj):
                     info[key][element[key]] = len(signature)
 
     for key in ["type", "extension", "mime"]:
-        info[key] = [element for element in sorted(info[key], key=info[key].get, reverse=True)]
+        info[key] = sorted(info[key], key=info[key].get, reverse=True)
 
     return Info(info["type"], info["extension"], info["mime"])
 


### PR DESCRIPTION
List Comprehension is unnecessary here. 

`sorted` already returned the list.